### PR TITLE
Adding sub delegatemodel to qml ...

### DIFF
--- a/BankView.qml
+++ b/BankView.qml
@@ -10,6 +10,8 @@ Rectangle {
     height: bank_view_column.height
     color: "#946782"
 
+    property var bankIndex
+
     Column {
         id: bank_view_column
         spacing: 0
@@ -26,6 +28,10 @@ Rectangle {
             id: description
             isOpened: checker.checked
             width: bank_view.width
+            coefficients: DelegateModel {
+                model: cfg
+                rootIndex: bankIndex
+            }
         }
     }
 

--- a/BankViewDescription.qml
+++ b/BankViewDescription.qml
@@ -10,6 +10,7 @@ RowLayout {
     clip: true
 
     property bool isOpened: false
+    property alias coefficients : regs.model
 
     Behavior on isOpened {
         NumberAnimation {
@@ -33,6 +34,9 @@ RowLayout {
                 height: 200
                 color: "#62f9c1"
                 Layout.alignment: Qt.AlignCenter
+                Label { //to debug
+                    text: "#" + regs.count
+                }
             }
 
             ListView {
@@ -42,17 +46,14 @@ RowLayout {
                 width: 320
                 Layout.alignment: Qt.AlignCenter
                 Layout.maximumHeight: 5 * 36
-                model: DelegateModel {
-                    model: model.index(index, 0, model.modelIndex(index))
-                    delegate: Row {
-                        TextField {
-                            text: coefficient
-                            implicitWidth: regs.width
-                            height: 36
-                            background: Rectangle {
-                                anchors.fill: parent
-                                color: "#F2F402"
-                            }
+                delegate: Row {
+                    TextField {
+                        text: "#" + coefficient
+                        implicitWidth: regs.width
+                        height: 36
+                        background: Rectangle {
+                            anchors.fill: parent
+                            color: "#F2F402"
                         }
                     }
                 }

--- a/configmodel.cpp
+++ b/configmodel.cpp
@@ -118,3 +118,11 @@ void ConfigModel::setModelUp(const QVector<QVector<quint32> >& config)
             _root_item->childAt(_root_item->childrenCount() - 1)->appendChild(new CoefficientItem(coefficient));
     }
 }
+
+
+QHash<int, QByteArray> ConfigModel::roleNames() const
+{
+    return {
+        {CoefficientRole, "coefficient"},
+    };
+}

--- a/configmodel.h
+++ b/configmodel.h
@@ -30,6 +30,8 @@ public:
 
     void setModelUp(const QVector<QVector<quint32> >& config);
 
+    QHash<int, QByteArray> roleNames() const override;
+
 private:
     CoefficientItem* _root_item;
 };

--- a/main.qml
+++ b/main.qml
@@ -30,7 +30,9 @@ Window {
                 anchors.fill: parent
                 model: DelegateModel {
                     model: cfg
-                    delegate: BankView {}
+                    delegate: BankView {
+                        bankIndex: cfg.index(index, 0)
+                    }
                 }
             }
         }


### PR DESCRIPTION
BankView now has a property that tells the BankView where in `cfg` it exists. This is used to prep a DelegateModel, which then represents the coefficients in that particular Bank.
The BankViewDescription then uses the "coefficients" property in the ListView.

I also had to add roleNames because that's how QML rolls (pun intended ;-) )

Currently it seems your ConfigModel is not properly giving back it's children (Added a label with count for debugging). Let me know if you need help here